### PR TITLE
Hide floorplan on small screens

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 let currentViewer = null;
 let autoRotateOn = true;
+let floorplanVisible = true;
 
 const scenes = window.SCENES || {};
 const buttonsContainer = document.getElementById('scene-buttons');
@@ -111,7 +112,24 @@ window.addEventListener('DOMContentLoaded', () => {
   const fp = document.getElementById('floorplan');
   btnFloorplan?.addEventListener('click', () => {
     if (!fp || !btnFloorplan) return;
-    const isHidden = fp.classList.toggle('hidden');
-    btnFloorplan.textContent = isHidden ? 'Show Map' : 'Hide Map';
+    floorplanVisible = !floorplanVisible;
+    fp.classList.toggle('hidden', !floorplanVisible);
+    btnFloorplan.textContent = floorplanVisible ? 'Hide Map' : 'Show Map';
   });
+
+  function handleResize() {
+    if (!fp || !btnFloorplan) return;
+    const small = window.innerWidth < 768;
+    if (small) {
+      fp.classList.add('hidden');
+      btnFloorplan.classList.add('hidden');
+    } else {
+      btnFloorplan.classList.remove('hidden');
+      fp.classList.toggle('hidden', !floorplanVisible);
+      btnFloorplan.textContent = floorplanVisible ? 'Hide Map' : 'Show Map';
+    }
+  }
+
+  handleResize();
+  window.addEventListener('resize', handleResize);
 });

--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
 
     <nav id="scene-buttons" class="absolute top-4 right-4 flex gap-2 z-10"></nav>
 
-    <button id="btn-floorplan" title="Toggle floor plan" class="absolute bottom-4 right-4 px-3 py-1 bg-white/10 border border-white/20 rounded-md text-white text-xs z-10">Hide Map</button>
+    <button id="btn-floorplan" title="Toggle floor plan" class="hidden absolute bottom-4 right-4 px-3 py-1 bg-white/10 border border-white/20 rounded-md text-white text-xs z-10">Hide Map</button>
 
-    <div id="floorplan" class="absolute bottom-16 right-4 w-80 h-80 bg-white/10 border border-white/20 rounded-md overflow-hidden z-10">
+    <div id="floorplan" class="hidden absolute bottom-16 right-4 w-80 h-80 bg-white/10 border border-white/20 rounded-md overflow-hidden z-10">
       <div class="relative w-full h-full">
         <img src="https://i.postimg.cc/GmWm48bj/FLOORPLAN.png" alt="Floor Plan" class="w-full h-full object-contain">
         <button id="fp-pin"


### PR DESCRIPTION
## Summary
- hide floor plan map and toggle button on small screens
- add responsive resize handler so map returns on larger viewports

## Testing
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea7e344a4832288a9566505f2e5a6